### PR TITLE
Fix build of tools with GCC 13

### DIFF
--- a/tools/common.h
+++ b/tools/common.h
@@ -5,6 +5,7 @@
 
 #include <iostream>
 #include <string>
+#include <cstdint>
 
 
 #if defined(WIN32) || defined(_WIN32)


### PR DESCRIPTION
With GCC 13 the build fails because it does not know the integer types (uint8_t, uint16_t, ...).
Make them known by including cstdint.

See also: https://bugs.debian.org/1042164

(ping @FeralChild64)