### PR TITLE
Add init screen code at E536

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -375,6 +375,7 @@ Not all of them - only these we want to have implemented.
 | `$E51B`   | init screen keyboard, no VIC | DONE     |                                                    |
 | `$E544`   | clear screen                 | DONE     |                                                    |
 | `$E50C`   | set cursor position          | DONE     |                                                    |
+| `$E536`   | init screen ?                | PARTIAL  |                                                    |
 | `$E566`   | home cursor                  | DONE     |                                                    |
 | `$E56C`   | set PNT and USER values      | DONE     |                                                    |
 | `$E5A0`   | setup VIC II & I/O           | DONE     |                                                    |

--- a/src/kernal/screen/e536.init_screen.s
+++ b/src/kernal/screen/e536.init_screen.s
@@ -1,0 +1,21 @@
+;; #LAYOUT# STD *        #TAKE
+;; #LAYOUT# X16 *        #IGNORE
+;; #LAYOUT# *   KERNAL_0 #TAKE
+;; #LAYOUT# *   *        #IGNORE
+
+;
+; Init screen at reset
+;
+; https://www.c64-wiki.com/wiki/646
+; https://www.lemon64.com/forum/viewtopic.php?t=18490
+;
+; Information on what the code at E536 does is a bit contradictory
+; It seems as if the text color at $286 is set to the value in A
+; and then the screen is cleared.
+; Tests indicate that this is the what happens.
+    
+
+init_screen:
+
+    sta $0286
+    jmp clear_screen


### PR DESCRIPTION
I found that one version of Bruce Lee was stopped when calling this address and I tried to figure out what it was supposed to do. Online sources tell slightly different stories. It seems as if it sets the text colour (at $0286) from the accumulator and clears the screen. I tested with a real C64 kernal and this seems to be confirmed.

After adding this code the Bruce Lee game starts and can run.