### PR TITLE
Fixes after testing of convert int to FAC functions

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -200,7 +200,7 @@ Floating point mathematical routines - not official, but well known and broadly 
 | `$B1AA`   | `FACINX`               | NOT DONE | convert FAC1 to 16-bit signed integer              |
 | `$B1BF`   | `convert_FAC1_to_s16`  | NOT DONE |                                                    |
 | `$B391`   | `GIVAYF`               | PARTIAL  | not fully tested yet                               |
-| `$B3A2`   | `convert_Y_to_FAC1`    | PARTIAL  | not fully tested yet                               |
+| `$B3A2`   | `convert_Y_to_FAC1`    | DONE     |                                                    |
 | `$B794`   | `convert_A_to_FAC1`    | NOT DONE |                                                    |
 | `$B7B5`   | `STRVAL`               | NOT DONE | imports string to FAC1                             |
 | `$B7F7`   | `convert_FAC1_to_ADDR` | NOT DONE |                                                    |
@@ -233,8 +233,8 @@ Floating point mathematical routines - not official, but well known and broadly 
 | `$BC1B`   | `round_FAC1`           | PARTIAL  | not fully tested yet                               |
 | `$BC2B`   | `sgn_FAC1_A`           | DONE     |                                                    |
 | `$BC39`   | `sgn_FAC1`             | DONE     |                                                    |
-| `$BC3C`   | `convert_A_to_FAC1`    | PARTIAL  | not fully tested yet                               |
-| `$BC44`   | `convert_i16_to_FAC1`  | PARTIAL  | not fully tested yet                               |
+| `$BC3C`   | `convert_A_to_FAC1`    | DONE     |                                                    |
+| `$BC44`   | `convert_i16_to_FAC1`  | DONE     |                                                    |
 | `$BC58`   | `abs_FAC1`             | NOT DONE |                                                    |
 | `$BC5B`   | `FCOMP`                | NOT DONE | compare FAC1 with RAM location                     |
 | `$BC9B`   | `QINT`                 | NOT DONE | convert FAC1 to 32 bit signed integer              |

--- a/src/basic/math/b3a2.convert_Y_to_FAC1.s
+++ b/src/basic/math/b3a2.convert_Y_to_FAC1.s
@@ -18,7 +18,7 @@
 ;
 
 convert_Y_to_FAC1:
+    sty FAC1_mantissa+1
     lda #$00
-    sta FAC1_mantissa+1
-    sty FAC1_mantissa
+    sta FAC1_mantissa
     jmp convert_i16_to_FAC1

--- a/src/basic/math/bc3c.convert_A_to_FAC1.s
+++ b/src/basic/math/bc3c.convert_A_to_FAC1.s
@@ -17,8 +17,8 @@
 
 
 convert_A_to_FAC1:
-    sta FAC1_mantissa
+    sta FAC1_mantissa+1
     jsr sign_extend_A_to_Y
-    sty FAC1_mantissa+1
+    sty FAC1_mantissa
     +nop                    ; To not leave a gap to the fallthrough
     ; Fall through to convert_i16_to_FAC1

--- a/src/basic/math/bc44.convert_i16_to_FAC1.s
+++ b/src/basic/math/bc44.convert_i16_to_FAC1.s
@@ -24,6 +24,6 @@ convert_i16_to_FAC1:
 
 
 carry:
-    lda FAC1_mantissa+1
+    lda FAC1_mantissa
     cmp #$80                    ; Copy sign into carry
     rts

--- a/src/basic/math/convert_i16_expsign_to_FAC1.s
+++ b/src/basic/math/convert_i16_expsign_to_FAC1.s
@@ -12,12 +12,12 @@ convert_i16_expsign_to_FAC1:
     sta FAC1_mantissa+3
     stx FAC1_exponent
     sta FAC1_sign
-    bcs @1
+    bcc @1
 
     ; Handle signed int
-    lda FAC1_mantissa+1          ; Clear sign bit of int 16
+    lda FAC1_mantissa            ; Clear sign bit of int 16
     and #$7F
-    sta FAC1_mantissa+1
+    sta FAC1_mantissa
     ldy #>CONST_NEG_32768       ; Subtract with 32768 to invert negative number
     lda #<CONST_NEG_32768
     jsr add_MEM_FAC1

--- a/strings/202BBC85
+++ b/strings/202BBC85
@@ -1,0 +1,3 @@
+JSR $BC2B + STA fragment
+
+Calls the SGN FAC1 into A which is a well known routine and then stores the result in the zero page. Trivial

--- a/strings/202BBC8562
+++ b/strings/202BBC8562
@@ -1,3 +1,0 @@
-JSR $BC2B + STA $62
-
-Calls the SGN FAC1 into A which is a well known routine and then stores the result in the FAC1 mantissa. Trivial


### PR DESCRIPTION
I tested the following functions using the monitor in Vice:

* `convert_Y_to_FAC1`
* `convert_A_to_FAC1`
* `convert_i16_to_FAC1`

and found that I had mixed up the order of the bytes in the mantissa. With this the functions should work as intended.