### PR TITLE
Add unit test program and some unit tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -869,7 +869,7 @@ $(TARGET_X16_x): $(SEG_LIST_X16) build/chargen_openroms.rom
 
 .PHONY: test test_crt test_generic test_generic_x128 test_generic_crt test_hybrid test_testing \
         test_mega65 test_mega65_xemu test_m65 test_ultimate64 \
-        testremote testsimilarity
+        testremote testsimilarity testunit
 
 test:     test_custom
 test_crt: test_generic_crt
@@ -931,6 +931,14 @@ testremote: build/kernal_custom.rom build/basic_custom.rom $(TARGET_CHR_PXL) bui
 testsimilarity: $(TOOL_SIMILARITY) $(DIR_GEN)/OUTx_x.BIN $(ROM_CBM_KERNAL) $(ROM_CBM_BASIC)
 	$(TOOL_SIMILARITY) $(ROM_CBM_KERNAL) $(DIR_GEN)/OUTx_x.BIN
 	$(TOOL_SIMILARITY) $(ROM_CBM_BASIC)  $(DIR_GEN)/OUTx_x.BIN
+
+build/testresults: testsuite/unit/testresults.cc
+	$(CXX) -std=c++20 -O2 -Wall -o $@ $<
+
+testunit: $(TARGET_LIST_TST38) $(TARGET_CHR_PXL) build/testresults
+	rm -f build/output
+	$(EXEC_X64) -kernal $(TARGET_TST38_K) -basic $(TARGET_TST38_B) -chargen $(TARGET_CHR_PXL) -moncommands testsuite/unit/math.vs -initbreak ready
+	cd build; ./testresults
 
 #
 # Z80 part

--- a/testsuite/unit/math.vs
+++ b/testsuite/unit/math.vs
@@ -1,0 +1,108 @@
+# Unit tests for basic math functions
+
+log on
+logname "build/output"
+
+print "TEST: float const 10.0"
+fill $1001 $1005 84 20 00 00 00
+print "COMPARE"
+compare $BAF9 $BAFD $1001
+print "END"
+
+print "TEST: float const 1.0"
+fill $1001 $1005 81 00 00 00 00
+print "COMPARE"
+compare $B9BC $B9C0 $1001
+print "END"
+
+print "TEST: float const 0.5"
+fill $1001 $1005 80 00 00 00 00
+print "COMPARE"
+compare $BF11 $BF15 $1001
+print "END"
+
+print "TEST: float const -0.5"
+fill $1001 $1005 80 80 00 00 00
+print "COMPARE"
+compare $B9E0 $B9E4 $1001
+print "END"
+
+print "TEST: float const 0.25"
+fill $1001 $1005 7F 00 00 00 00
+print "COMPARE"
+compare $E2EA $E2EE $1001
+print "END"
+
+print "TEST: convert_A_to_FAC1 A=0"
+r A=0
+r PC=$BC3C
+ret
+fill $1001 $1001 00
+print "COMPARE"
+compare $61 $61 $1001
+print "END"
+
+print "TEST: convert_A_to_FAC1 A=1"
+r A=1
+r PC=$BC3C
+ret
+fill $1001 $1007 81 80 00 00 00 00 00
+print "COMPARE"
+compare $61 $67 $1001
+print "END"
+
+print "TEST: convert_A_to_FAC1 A=127"
+r A=$7F
+r PC=$BC3C
+ret
+fill $1001 $1007 87 FE 00 00 00 00 00
+print "COMPARE"
+compare $61 $67 $1001
+print "END"
+
+print "TEST: convert_A_to_FAC1 A=-128"
+r A=$80
+r PC=$BC3C
+ret
+fill $1001 $1007 88 80 00 00 00 FF 00
+print "COMPARE"
+compare $61 $67 $1001
+print "END"
+
+print "TEST: convert_Y_to_FAC1 Y=1"
+r Y=1
+r PC=$B3A2
+ret
+fill $1001 $1007 81 80 00 00 00 00 00
+print "COMPARE"
+compare $61 $67 $1001
+print "END"
+
+print "TEST: convert_Y_to_FAC1 Y=0"
+r Y=0
+r PC=$B3A2
+ret
+fill $1001 $1001 00
+print "COMPARE"
+compare $61 $61 $1001
+print "END"
+
+print "TEST: convert_Y_to_FAC1 Y=127"
+r Y=$7F
+r PC=$B3A2
+ret
+fill $1001 $1007 87 FE 00 00 00 00 00
+print "COMPARE"
+compare $61 $67 $1001
+print "END"
+
+print "TEST: convert_Y_to_FAC1 Y=255"
+r Y=$FF
+r PC=$B3A2
+ret
+fill $1001 $1007 88 FF 00 00 00 00 00
+print "COMPARE"
+compare $61 $67 $1001
+print "END"
+
+q

--- a/testsuite/unit/testresults.cc
+++ b/testsuite/unit/testresults.cc
@@ -1,0 +1,39 @@
+#include <fstream>
+#include <iostream>
+
+// Program to parse output of vice monitor script tests
+// Outputs a list of tests and information from failing tests
+
+
+int main()
+{
+    std::ifstream file("output");
+    std::string line;
+    bool in_compare = false;
+    bool failed = false;
+
+    while (getline(file, line)) {
+        if (line.starts_with("ERROR -- Wrong syntax:")) {
+            getline(file, line);
+            if (line.starts_with("  print \"TEST: ")) {
+                std::cout << line.substr(9, line.size() - 10) << std::endl;
+            } else if (line.starts_with("  print \"COMPARE")) {
+                getline(file, line);
+                in_compare = true;
+            } else if (line.starts_with("  print \"END")) {
+                in_compare = false;
+            }
+        } else if (in_compare) {
+            std::cout << "\033[31mFAIL:\033[0m " << line << std::endl;
+            failed = true;
+        }
+    }
+     
+    if (failed) {
+        std::cout << "Some tests \033[31mFAIL\033[0m " << std::endl;
+        return 1;
+    } else {
+        std::cout << "All tests \033[32mPASS\033[0m " << std::endl;
+        return 0;
+    }
+}


### PR DESCRIPTION
Add unit tests:

* Using the vice monitor to run unit tests
* Add program to parse output of monitor scripts
* Add test script for `convert_A_to_FAC1`, `convert_Y_to_FAC1` and some math constants
* Unit tests can be built and run with `make testunit`

When developing and refactoring math functions I found it hard to be without unit tests. The best/easiest way I could find was to use the vice monitor together with a custom program to parse the output from the monitor. Let me know what you think. At least I found this quite useful while developing.