### PR TITLE
Add polynomials for the transcendental functions

### DIFF
--- a/src/,,config_testing_38K.s
+++ b/src/,,config_testing_38K.s
@@ -97,7 +97,7 @@
 ; --- Software features
 
 ;; #CONFIG# PANIC_SCREEN               YES
-;; #CONFIG# DOS_WEDGE                  YES
+;; #CONFIG# DOS_WEDGE                  NO
 ;; #CONFIG# TAPE_WEDGE                 YES
 ;; #CONFIG# TAPE_HEAD_ALIGN            NO
 ;; #CONFIG# BCD_SAFE_INTERRUPTS        YES

--- a/src/basic/,stubs_math/b9ea.log_FAC1.s
+++ b/src/basic/,stubs_math/b9ea.log_FAC1.s
@@ -18,3 +18,13 @@
 log_FAC1:
 
 	+STUB_IMPLEMENTATION
+
+
+poly_log:
+
+    !byte $03                          ; series length - 1
+
+    +PUT_CONST_POLY_LOG_1
+    +PUT_CONST_POLY_LOG_2
+    +PUT_CONST_POLY_LOG_3
+    +PUT_CONST_POLY_LOG_4

--- a/src/basic/,stubs_math/e30e.atn_FAC1.s
+++ b/src/basic/,stubs_math/e30e.atn_FAC1.s
@@ -16,3 +16,20 @@
 atn_FAC1:
 
 	+STUB_IMPLEMENTATION
+	
+poly_atn:
+
+    !byte $0B                          ; series length - 1
+
+    +PUT_CONST_POLY_ATN_1
+    +PUT_CONST_POLY_ATN_2
+    +PUT_CONST_POLY_ATN_3
+    +PUT_CONST_POLY_ATN_4
+    +PUT_CONST_POLY_ATN_5
+    +PUT_CONST_POLY_ATN_6
+    +PUT_CONST_POLY_ATN_7
+    +PUT_CONST_POLY_ATN_8
+    +PUT_CONST_POLY_ATN_9
+    +PUT_CONST_POLY_ATN_10
+    +PUT_CONST_POLY_ATN_11
+    +PUT_CONST_POLY_ATN_12

--- a/src/basic/math/poly_exp.s
+++ b/src/basic/math/poly_exp.s
@@ -1,0 +1,19 @@
+;; #LAYOUT# STD *       #TAKE
+;; #LAYOUT# X16 BASIC_0 #TAKE-OFFSET 2000
+;; #LAYOUT# *  BASIC_0  #TAKE
+;; #LAYOUT# *   *       #IGNORE
+
+; Polynomial for the exponential function
+
+poly_exp:
+
+    !byte $07                          ; series length - 1
+
+    +PUT_CONST_POLY_EXP_1
+    +PUT_CONST_POLY_EXP_2
+    +PUT_CONST_POLY_EXP_3
+    +PUT_CONST_POLY_EXP_4
+    +PUT_CONST_POLY_EXP_5
+    +PUT_CONST_POLY_EXP_6
+    +PUT_CONST_POLY_EXP_7
+    +PUT_CONST_POLY_EXP_8

--- a/strings/0091146020
+++ b/strings/0091146020
@@ -1,0 +1,1 @@
+Part of the polynomial for log approximation. This is a well known polynomial taken from the book "Computer Approximations" by John Fraser Hart et al. (ISBN 0-88275-642-7) according to https://www.c64-wiki.com/wiki/POLY1

--- a/strings/037F5E56CB7980139B0B6480763893168238AA3B20
+++ b/strings/037F5E56CB7980139B0B6480763893168238AA3B20
@@ -1,0 +1,1 @@
+Part of the polynomial for log approximation. This is a well known polynomial taken from the book "Computer Approximations" by John Fraser Hart et al. (ISBN 0-88275-642-7) according to https://www.c64-wiki.com/wiki/POLY1

--- a/strings/0584E61A2D1B862807FBF88799688901872335DFE186A55DE72883490FDAA2
+++ b/strings/0584E61A2D1B862807FBF88799688901872335DFE186A55DE72883490FDAA2
@@ -1,0 +1,1 @@
+The polynomial for sin approximation. This is a well known polynomial taken from the book "Computer Approximations" by John Fraser Hart et al. (ISBN 0-88275-642-7) according to https://www.c64-wiki.com/wiki/POLY1

--- a/strings/077134583E5674167EB31B772FEEE3857A1D841C2A7C6359580A7E75FDE7C680317218108100000000
+++ b/strings/077134583E5674167EB31B772FEEE3857A1D841C2A7C6359580A7E75FDE7C680317218108100000000
@@ -1,0 +1,1 @@
+This is the polyonmial for the exponential function. According to https://www.c64-wiki.com/wiki/POLY1 this was most likely taken from the book "Computer Approximations" by John Fraser Hart et al. (ISBN 0-88275-642-7). This is then a well known polynomial.

--- a/strings/600B76B383BDD3791EF4A6F57B83FCB0107C0C1F67CA7CDE53CBC17D1464704C7DB7EA517A7D6330887E7E9244993A7E4CCC91C77FAAAAAA138100000000
+++ b/strings/600B76B383BDD3791EF4A6F57B83FCB0107C0C1F67CA7CDE53CBC17D1464704C7DB7EA517A7D6330887E7E9244993A7E4CCC91C77FAAAAAA138100000000
@@ -1,0 +1,1 @@
+The polynomial for atn approximation. This is a well known polynomial taken from the book "Computer Approximations" by John Fraser Hart et al. (ISBN 0-88275-642-7) according to https://www.c64-wiki.com/wiki/POLY1

--- a/tools/generate_constants.cc
+++ b/tools/generate_constants.cc
@@ -58,16 +58,6 @@ std::vector<ConstEntry> GLOBAL_constants =
 	ConstEntry(     "LOG_2", std::log(2.0)        ),
 	ConstEntry( "INV_LOG_2", 1.0 / std::log(2.0)  ),
 
-	// Constants for sine approximation, minimized abs. error, degree 11, for [0, pi/2], from:
-	// - https://publik-void.github.io/sin-cos-approximations/
-
-	ConstEntry( "POLY_SIN_1", -2.3794713545277060334805162803882547e-8   ),
-	ConstEntry( "POLY_SIN_2",  2.75188556386854406868696924998396177e-6  ),
-	ConstEntry( "POLY_SIN_3", -0.000198407028626057951892931706291369095 ),
-	ConstEntry( "POLY_SIN_4",  0.00833332926445715285723741015926085083  ),
-	ConstEntry( "POLY_SIN_5", -0.166666665414391662957238076832950332    ),
-	ConstEntry( "POLY_SIN_6",  0.99999999988985190065414932682350994     ),
-
 	// Constants for exp approximation, taken from https://www.c64-wiki.com/wiki/POLY1
 	// original source is probably "Computer Approximations" by John Fraser Hart et al. (ISBN 0-88275-642-7)
 	ConstEntry( "POLY_EXP_1", 2.1498763701e-5 ),
@@ -78,6 +68,14 @@ std::vector<ConstEntry> GLOBAL_constants =
 	ConstEntry( "POLY_EXP_6", 0.24022638460   ),
 	ConstEntry( "POLY_EXP_7", 0.69314718618   ),
 	ConstEntry( "POLY_EXP_8", 1.0             ),
+
+    // Constants for sin approximation, source as for exp above
+	ConstEntry( "POLY_SIN_1", -14.381390672 ),
+	ConstEntry( "POLY_SIN_2", 42.007797122  ),
+	ConstEntry( "POLY_SIN_3", -76.704170257 ),
+	ConstEntry( "POLY_SIN_4", 81.605223686  ),
+	ConstEntry( "POLY_SIN_5", -41.341702104 ),
+	ConstEntry( "POLY_SIN_6", 6.2831853069  ),
 
     // Constants for log approximation, source as for exp above
     ConstEntry( "POLY_LOG_1", 0.43425594189   ),

--- a/tools/generate_constants.cc
+++ b/tools/generate_constants.cc
@@ -78,6 +78,12 @@ std::vector<ConstEntry> GLOBAL_constants =
 	ConstEntry( "POLY_EXP_6", 0.24022638460   ),
 	ConstEntry( "POLY_EXP_7", 0.69314718618   ),
 	ConstEntry( "POLY_EXP_8", 1.0             ),
+
+    // Constants for log approximation, source as for exp above
+    ConstEntry( "POLY_LOG_1", 0.43425594189   ),
+    ConstEntry( "POLY_LOG_2", 0.57658454124   ),
+    ConstEntry( "POLY_LOG_3", 0.96180075919   ),
+    ConstEntry( "POLY_LOG_4", 2.8853900731    ),
 };
 
 //

--- a/tools/generate_constants.cc
+++ b/tools/generate_constants.cc
@@ -84,6 +84,20 @@ std::vector<ConstEntry> GLOBAL_constants =
     ConstEntry( "POLY_LOG_2", 0.57658454124   ),
     ConstEntry( "POLY_LOG_3", 0.96180075919   ),
     ConstEntry( "POLY_LOG_4", 2.8853900731    ),
+
+    // Constants for atn approximation, source as for exp above
+    ConstEntry( "POLY_ATN_1", -6.8479391189e-4 ),
+    ConstEntry( "POLY_ATN_2", 4.8509421558e-3  ),
+    ConstEntry( "POLY_ATN_3", -1.6111701843e-2 ),
+    ConstEntry( "POLY_ATN_4", 3.4209638048e-2  ),
+    ConstEntry( "POLY_ATN_5", -5.4279132761e-2 ),
+    ConstEntry( "POLY_ATN_6", 7.2457196540e-2  ),
+    ConstEntry( "POLY_ATN_7", -8.9802395378e-2 ),
+    ConstEntry( "POLY_ATN_8", 0.11093241343    ),
+    ConstEntry( "POLY_ATN_9", -0.14283980767   ),
+    ConstEntry( "POLY_ATN_10", 0.19999912049   ),
+    ConstEntry( "POLY_ATN_11", -0.33333331568  ),
+    ConstEntry( "POLY_ATN_12", 1.0             ),
 };
 
 //

--- a/tools/generate_constants.cc
+++ b/tools/generate_constants.cc
@@ -67,6 +67,17 @@ std::vector<ConstEntry> GLOBAL_constants =
 	ConstEntry( "POLY_SIN_4",  0.00833332926445715285723741015926085083  ),
 	ConstEntry( "POLY_SIN_5", -0.166666665414391662957238076832950332    ),
 	ConstEntry( "POLY_SIN_6",  0.99999999988985190065414932682350994     ),
+
+	// Constants for exp approximation, taken from https://www.c64-wiki.com/wiki/POLY1
+	// original source is probably "Computer Approximations" by John Fraser Hart et al. (ISBN 0-88275-642-7)
+	ConstEntry( "POLY_EXP_1", 2.1498763701e-5 ),
+	ConstEntry( "POLY_EXP_2", 1.4352314037e-4 ),
+	ConstEntry( "POLY_EXP_3", 1.3422634825e-3 ),
+	ConstEntry( "POLY_EXP_4", 9.6140170135e-3 ),
+	ConstEntry( "POLY_EXP_5", 5.5505126860e-2 ),
+	ConstEntry( "POLY_EXP_6", 0.24022638460   ),
+	ConstEntry( "POLY_EXP_7", 0.69314718618   ),
+	ConstEntry( "POLY_EXP_8", 1.0             ),
 };
 
 //


### PR DESCRIPTION
Add the polynomials for `exp`,` log` and `atn` and also replace the polynomial for `sin`.

All polynomials used are from https://www.c64-wiki.com/wiki/POLY1 which claims that they are the original ones in BASIC 2.0, which in turn most likely are coming from the book "Computer Approximations" by John Fraser Hart et al. (ISBN 0-88275-642-7) since Microsoft cites using these in their GW BASIC.