### PR TITLE
3 bug fixes

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -47,6 +47,15 @@ The following ROM features are currently missing:
 * RS-232 support
 * NMI handling is incomplete
 
+# Features implemented differently
+
+## Serial buffer byte location
+
+The KERNAL CIOUT routine buffers the byte to be sent into a zero page location, because only when the next byte is sent
+or when UNLSN occurs, it is known whether the byte should be sent with EOI or not. In the CBM KERNAL, this location is
+BSOUR ($0095). The Open ROM KERNAL, this location is TBTCNT ($00A4).
+
+The CBM KERNAL already uses TBTCNT for serial input, so using it for output as well, could be more consistent.
 
 # Hardware support status
 

--- a/src/kernal/iec/ciout.s
+++ b/src/kernal/iec/ciout.s
@@ -30,7 +30,7 @@ ciout_store_in_buffer:
 
 	; Store in the buffer data to be sent next, return
 	pla
-	sta BSOUR
+	sta TBTCNT
 	rts
 	
 ciout_send_byte:

--- a/src/kernal/iec/ciout.s
+++ b/src/kernal/iec/ciout.s
@@ -29,6 +29,9 @@ CIOUT:
 ciout_store_in_buffer:
 
 	; Store in the buffer data to be sent next, return
+	;
+	; The CBM KERNAL uses BSOUR to buffer the byte. As a result of the clean-room
+	; process, it happened that our tx code uses TBTCNT.
 	pla
 	sta TBTCNT
 	rts

--- a/src/kernal/iec/iec_tx_flush.s
+++ b/src/kernal/iec/iec_tx_flush.s
@@ -16,7 +16,11 @@ iec_tx_flush:
 	lda C3PO
 	beq @1
 	sec ; send it with EOI
-	jsr iec_tx_byte ; send the command regardless of the status
+!ifdef CONFIG_IEC_JIFFYDOS {
+    jsr iec_tx_dispatch ; send the command regardless of the status
+} else {
+    jsr iec_tx_byte
+}
 @1:
 	pla
 	rts

--- a/src/kernal/iec_fast/jiffydos_tx_byte.s
+++ b/src/kernal/iec_fast/jiffydos_tx_byte.s
@@ -61,17 +61,18 @@ jiffydos_tx_byte:
 	ora C3PO
 	sta CIA2_PRA                       ; bits 6 and 7 on CLK/DATA
 
-	; Send low nibble; cycles: 4 + 3 + 4 + 2 + 2 + 2 + 4 = 21
+	; Send low nibble; cycles: 4 + 3 + 4 + 2 + 2 + 2 + 3 + 4 = 24
 	pla                                ; retrieve low nibble from stack
 	ora C3PO                           ; restore VIC-II and RS-232 bits
 	sta CIA2_PRA
 	lsr
 	lsr
 	and #%00110000                     ; clear everything but CLK/DATA
+	ora C3PO
 	sta CIA2_PRA
 
-	; Signal EOI if needed; cycles till no EOI: 3 + 3 + 2 + 2 + 4 = 14 
-	lda C3PO
+	; Signal EOI if needed; cycles till no EOI: 2 + 3 + 2 + 2 + 4 = 13
+	and #%00000011
 	ldx IECPROTO
 	beq jiffydos_tx_byte_wait_eoi
 
@@ -100,7 +101,7 @@ jiffydos_tx_byte_wait_eoi:
 	sta CIA2_PRA
 	jsr iec_wait20us
 	lda C3PO
-	
+
 	; According to protocol analysis by Michael Steil (step S8) we should pull the DATA here
 	; to signal there was no error; but DATA pulled by the controller is a normal state
 	; (which should be stored in C3PO), so there is nothing to do here.


### PR DESCRIPTION
Hello,

The low-level serial API cannot work as it is now, due to a few bugs. 3 bug fixes in the serial code:

- Ciout did store the byte to be transmitted in BSOUR while iec_tx_byte expects the byte to be transmitted in TBTCNT
- iex_tx_flush did call iec_tx_byte, but that is wrong is JiffyDOS is used, the byte needs to be transmitted using JiffyDOS protocol
- jiffydos_tx_byte tries tro avoid changing the VIC-II bank, but did not do that for the last 2 bits.

With these changes the code works and is able to do serial communication.