### PR TITLE
Include <sstream> header

### DIFF
--- a/tools/generate_strings/main.cc
+++ b/tools/generate_strings/main.cc
@@ -8,6 +8,7 @@
 
 #include <fstream>
 #include <regex>
+#include <sstream>
 #include <unistd.h>
 
 


### PR DESCRIPTION
Fixes build failure with recent compilers:

```
tools/generate_strings/main.cc: In function ‘void parseConfigFile()’:
tools/generate_strings/main.cc:72:46: error: variable ‘std::istringstream workStream’ has initializer but incomplete type
   72 |         std::istringstream workStream(workStr);
      |                                              ^
```